### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ USER appuser
 COPY . .
 
 # Run the application.
-CMD ["python" "-m" "bot"]
+CMD ["python", "-m", "bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # https://docs.docker.com/engine/reference/builder/
 
 ARG PYTHON_VERSION=3.11.7
-FROM python:${PYTHON_VERSION}-slim as base
+FROM python:${PYTHON_VERSION}-slim AS base
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -43,4 +43,4 @@ USER appuser
 COPY . .
 
 # Run the application.
-CMD python -m bot
+CMD ["python" "-m" "bot"]


### PR DESCRIPTION
The 'as' keyword should match the case of the 'from' keyword
FromAsCasing: 'as' and 'FROM' keywords' casing do not match More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/

JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals
JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/